### PR TITLE
Fix webpack via gulp

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,15 +18,7 @@ gulp.task('webpack', cb => {
         'webpack/hot/only-dev-server'
     );
 
-    const compiler = webpack(webpackDevConfig, (err, stats) => {
-        if (err) {
-            throw new gulpUtil.PluginError('webpack', err);
-        }
-
-        if (stats.compilation.errors.length) {
-            gulpUtil.log('webpack', '\n' + stats.toString({ colors: true }));
-        }
-    });
+    const compiler = webpack(webpackDevConfig);
 
     new WebpackDevServer(compiler,
         webpackDevConfig.devServer


### PR DESCRIPTION
By passing a callback to the webpack() call (the one that creates the
compiler), you were requesting a compilation to be done. Removing that
callback instead just creates a compiler that you can then pass off to
the webpack dev server. This wasn't a happypack issue.
